### PR TITLE
Underscore support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,6 @@
         "eslint-plugin-storybook": "0.6.8",
         "read-pkg-up": "7.0.1"
       },
-      "bin": {
-        "fullstacksjs-eslint": "bin/index.js"
-      },
       "devDependencies": {
         "@semantic-release/github": "8.0.7",
         "@semantic-release/npm": "9.0.1",

--- a/rules/naming-convention.js
+++ b/rules/naming-convention.js
@@ -15,7 +15,7 @@ module.exports = [
   {
     selector: 'parameter',
     format: ['camelCase', 'PascalCase'],
-    leadingUnderscore: 'allowSingleOrDouble',
+    leadingUnderscore: 'allow',
   },
   {
     selector: 'memberLike',
@@ -46,5 +46,11 @@ module.exports = [
     selector: 'interface',
     format: ['PascalCase'],
     custom: { regex: '^I[A-Z]', match: false },
+  },
+  {
+    selector: 'variable',
+    types: ['boolean'],
+    format: ['PascalCase'],
+    prefix: ['is', 'should', 'has', 'can', 'did', 'will', 'enable', 'loading'],
   },
 ];

--- a/rules/naming-convention.js
+++ b/rules/naming-convention.js
@@ -59,10 +59,4 @@ module.exports = [
     format: ['PascalCase'],
     custom: { regex: '^I[A-Z]', match: false },
   },
-  {
-    selector: 'variable',
-    types: ['boolean'],
-    format: ['PascalCase'],
-    prefix: ['is', 'should', 'has', 'can', 'did', 'will', 'enable', 'loading'],
-  },
 ];

--- a/rules/naming-convention.js
+++ b/rules/naming-convention.js
@@ -2,6 +2,10 @@ module.exports = [
   {
     selector: 'default',
     format: ['camelCase'],
+    filter: {
+      regex: '^_+$',
+      match: false,
+    },
   },
   {
     selector: 'function',
@@ -11,11 +15,19 @@ module.exports = [
   {
     selector: 'variable',
     format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+    filter: {
+      regex: '^_+$',
+      match: false,
+    },
   },
   {
     selector: 'parameter',
     format: ['camelCase', 'PascalCase'],
     leadingUnderscore: 'allow',
+    filter: {
+      regex: '^_+$',
+      match: false,
+    },
   },
   {
     selector: 'memberLike',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -72,7 +72,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars-experimental': 'off', // Why two rules?
     '@typescript-eslint/no-unused-vars': [
       'warn',
-      { argsIgnorePattern: '^_', varsIgnorePattern: '^[iI]gnore(d)?', args: 'after-used', ignoreRestSiblings: true },
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^([iI]gnore(d)?)|(_+)', args: 'after-used', ignoreRestSiblings: true },
     ],
     '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: true }],
     '@typescript-eslint/no-useless-constructor': 'error',


### PR DESCRIPTION
I thought maybe having underscore names as allowed ignored names might be a good idea

these are some examples that should match IMO:

```typescript
const _ = 2; // this variable is a valid ignored name
```   

```typescript
type Axis = [number, number, number];
const axis: Axis = [10, 2, 8];
const [x, _, z] = axis; // this variable is a valid ignored name
console.log(x + z);
```   

```typescript
type Index = [number, number, number, number];
function sumFirstAndLast([first, _, __, forth]: Index) {
  return first + forth;
}
```   