### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ export default init(
   {
     typescript: true,
     // You can pass extends here
-    rules {
+    rules: {
       'no-console': 'error'
     }
   },


### PR DESCRIPTION
fix: correct syntax by replacing "rules {" with "rules: {" in configuration