### PR TITLE
fix(readme): remove `$` from shell code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Installation
 
 ```sh
-$ npm install --save-dev @fullstacksjs/eslint-config eslint prettier
+npm install --save-dev @fullstacksjs/eslint-config eslint prettier
 ```
 
 ⚡️ That's it, you don't need to install any eslint-plugin!  If you already have some plugins installed, please remove them.


### PR DESCRIPTION
remove `$` from shell code blocks to prevent copy-paste errors.
Copy-pasting commands with `$` prefix causes errors in terminals. Removed the dollar signs to improve DX.