### PR TITLE
Fix ESLint rule conflict for empty `switch` cases

### DIFF
--- a/src/modules/base.mjs
+++ b/src/modules/base.mjs
@@ -85,7 +85,7 @@ function base(options = {}) {
       'no-extend-native': 'error',
       'no-extra-bind': 'error',
       'no-extra-label': 'error',
-      'no-fallthrough': 'error',
+      'no-fallthrough': ["error", { "allowEmptyCase": true }],
       'no-func-assign': 'error',
       'no-global-assign': 'error',
       'no-implicit-globals': 'error',


### PR DESCRIPTION
This PR updates the `no-fallthrough` ESLint rule by enabling the `allowEmptyCase` option.

Previously, `no-fallthrough` conflicted with `padding-line-between-statements`:

* `no-fallthrough` did not allow fallthrough from an empty `case` when there was a blank line before the next `case`.<br><img width="560" height="157" alt="image" src="https://github.com/user-attachments/assets/c0ea11ab-70e0-49aa-b530-00bf20da16dc" />              
* `padding-line-between-statements` requires a blank line, making it impossible to satisfy both rules at the same time. <br><img width="557" height="130" alt="image" src="https://github.com/user-attachments/assets/e8b25d3f-2df3-4747-a060-74c5b4172c33" />





Enabling `allowEmptyCase` resolves this conflict by allowing intentional fallthrough from empty `case` statements while preserving the required spacing between `case` blocks.
