### PR TITLE
Chore/august maintenance 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,26 +21,12 @@ npm install --save-dev @fullstacksjs/eslint-config eslint prettier
 To use the configuration, all you need is to export the generated config by the `defineConfig` function. It automatically enables required
 plugins with **Auto Module Detection**.
 
-### ESM
-
 ```js
 import { defineConfig } from '@fullstacksjs/eslint-config';
 
 export default defineConfig({
   typescript: {
     tsconfigRootDir: import.meta.dirname, // Recommended when using TypeScript
-  },
-});
-```
-
-### CJS
-
-```js
-const { defineConfig } = require('@fullstacksjs/eslint-config');
-
-module.exports = defineConfig({
-  typescript: {
-    tsconfigRootDir: __dirname, // Recommended when using TypeScript
   },
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,29 +9,29 @@
       "version": "11.3.1",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eslint-plugin": "5.17.2",
+        "@eslint-react/eslint-plugin": "5.18.3",
         "@eslint/compat": "2.1.0",
-        "@next/eslint-plugin-next": "16.2.10",
+        "@next/eslint-plugin-next": "16.3.0",
         "@stylistic/eslint-plugin": "5.10.0",
-        "@vitest/eslint-plugin": "1.6.23",
+        "@vitest/eslint-plugin": "1.6.27",
         "deepmerge": "4.3.1",
         "eslint-flat-config-utils": "3.2.0",
         "eslint-plugin-better-tailwindcss": "4.7.0",
-        "eslint-plugin-cypress": "6.4.3",
+        "eslint-plugin-cypress": "7.0.0",
         "eslint-plugin-import-x": "4.17.1",
-        "eslint-plugin-jest": "29.15.4",
+        "eslint-plugin-jest": "29.16.0",
         "eslint-plugin-jsx-a11y": "6.10.2",
-        "eslint-plugin-n": "18.2.1",
-        "eslint-plugin-perfectionist": "5.10.0",
-        "eslint-plugin-playwright": "2.10.5",
+        "eslint-plugin-n": "18.3.0",
+        "eslint-plugin-perfectionist": "5.10.1",
+        "eslint-plugin-playwright": "2.11.0",
         "eslint-plugin-prettier": "5.5.6",
         "eslint-plugin-promise": "7.3.0",
-        "eslint-plugin-react-refresh": "0.5.3",
+        "eslint-plugin-react-refresh": "0.5.4",
         "eslint-plugin-regexp": "3.1.1",
-        "eslint-plugin-storybook": "10.5.2",
-        "globals": "17.7.0",
+        "eslint-plugin-storybook": "10.5.7",
+        "globals": "17.10.0",
         "local-pkg": "1.2.1",
-        "typescript-eslint": "8.65.0"
+        "typescript-eslint": "8.67.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.3.6",
@@ -41,14 +41,14 @@
         "@semantic-release/release-notes-generator": "14.1.1",
         "@types/eslint": "9.6.1",
         "cspell": "10.0.1",
-        "eslint": "10.7.0",
+        "eslint": "10.8.1",
         "jest": "30.4.2",
         "pinst": "3.0.0",
-        "prettier": "3.9.5",
-        "semantic-release": "25.0.8",
-        "storybook": "10.5.2",
+        "prettier": "3.9.6",
+        "semantic-release": "25.0.9",
+        "storybook": "10.5.7",
         "typescript": "6.0.3",
-        "vite-plus": "0.2.6",
+        "vite-plus": "0.2.8",
         "vitest": "4.1.10"
       },
       "peerDependencies": {
@@ -1821,14 +1821,14 @@
       }
     },
     "node_modules/@eslint-react/ast": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.17.2.tgz",
-      "integrity": "sha512-zkWQ3vLHkfAtIyYi08fv4oHzAF/ORnEWwCpCePeqp1HSKzmxr2VqZ+Vxrk0WrOyGZHCaX/L/n+40Vg1qC3Jw9w==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.18.3.tgz",
+      "integrity": "sha512-/993Nnt9ZIn7sBQjXF/iLJ9llDtd9qztQrPNxQKwU3XLUv7m3a0EUMIe0A9Ygfw1lJz4not3VwcwMBahn/foVA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/typescript-estree": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/typescript-estree": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "string-ts": "^2.3.1"
       },
       "engines": {
@@ -1840,18 +1840,18 @@
       }
     },
     "node_modules/@eslint-react/core": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.17.2.tgz",
-      "integrity": "sha512-tN/EWkLsrsu4xHQ4iNGOnnKxzYwxGqc4svRdeKuImUDcmooz2TI85cpj+NgAHvOHvJKYIZY7XmA4H+X7x3ajsw==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.18.3.tgz",
+      "integrity": "sha512-N0FtKHkByoQOPRuGbHEtDRdcpa+Zs/b1/zGVYcS1g0416FFRIl4utXxOLZQj6OtHaIVXh2C6lJhJtIWfzPzCJQ==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/shared": "5.17.2",
-        "@eslint-react/var": "5.17.2",
-        "@typescript-eslint/scope-manager": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@eslint-react/var": "5.18.3",
+        "@typescript-eslint/scope-manager": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -1863,12 +1863,12 @@
       }
     },
     "node_modules/@eslint-react/eslint": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.17.2.tgz",
-      "integrity": "sha512-vkYRhS/f1njYuJXr6yJnMDiZSDuVpEywGvy+w5VzyFX5oIW3i0uWic7K+8bNNC9ZW19NHkJRt/ppW0c+XyL7kw==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.18.3.tgz",
+      "integrity": "sha512-zH5kDfeHYzly6wiYEleCEBdc7g8H+nKmxzhcZKmR1omrfTvzSndVIoLPrG8WYsgtYRqJdTg+NOGkAkXnoaTW4Q==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.64.0"
+        "@typescript-eslint/utils": "^8.66.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1879,18 +1879,18 @@
       }
     },
     "node_modules/@eslint-react/eslint-plugin": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.17.2.tgz",
-      "integrity": "sha512-Gn78+mY8Cf1njmxLF57M/Xv5f02veSHbPRovY83wRZIvGfujrfipQyXlem/JI9rLZcVGRcxdiWwaAnP21f/b+g==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.18.3.tgz",
+      "integrity": "sha512-gpzENfi+943orTyWWWwepWZoat3ePhEUO7lVwpiKhuRjo3i63O+nXG8Bg5gMpOa/t8b1ZTZI2PHh4/KcWx3aXw==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/shared": "5.17.2",
-        "eslint-plugin-react-dom": "5.17.2",
-        "eslint-plugin-react-jsx": "5.17.2",
-        "eslint-plugin-react-naming-convention": "5.17.2",
-        "eslint-plugin-react-rsc": "5.17.2",
-        "eslint-plugin-react-web-api": "5.17.2",
-        "eslint-plugin-react-x": "5.17.2"
+        "@eslint-react/shared": "5.18.3",
+        "eslint-plugin-react-dom": "5.18.3",
+        "eslint-plugin-react-jsx": "5.18.3",
+        "eslint-plugin-react-naming-convention": "5.18.3",
+        "eslint-plugin-react-rsc": "5.18.3",
+        "eslint-plugin-react-web-api": "5.18.3",
+        "eslint-plugin-react-x": "5.18.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1901,17 +1901,17 @@
       }
     },
     "node_modules/@eslint-react/jsx": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.17.2.tgz",
-      "integrity": "sha512-UXwWc/FOk3g95SlJP6w/8nCPSlc5kKePKYSnnyWCfjxBLBo/MaAa8G+GcYWNNy1LjaPGO7CCc3+T/0xd1Oh/2Q==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.18.3.tgz",
+      "integrity": "sha512-1MHb4HWOxk6UUg/PRMdrlu7AS1aLPKuz/lWNKfq27th3HCdxyppkg8FQLnU0GQoNnzyH2QoCvL6Um16rdyi7vA==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/shared": "5.17.2",
-        "@eslint-react/var": "5.17.2",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@eslint-react/var": "5.18.3",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -1923,13 +1923,13 @@
       }
     },
     "node_modules/@eslint-react/shared": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.17.2.tgz",
-      "integrity": "sha512-WBdPJdGk2uRaoXqd55re8y99Myco9WuMRCBBl67a9pyTogfMZuXYLJI4Xcr0wBv282NT+IpHw1RA1o4pbPuCmw==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.18.3.tgz",
+      "integrity": "sha512-r+ZxSYVHDTu6n4/75+94UWvMMoFSwx9rVm8OBJLVpfcxQEqpOSPtEPn7HmXaxsCg12N1os5bxqajWudKOM1Ydw==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eslint": "5.17.2",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/eslint": "5.18.3",
+        "@typescript-eslint/utils": "^8.66.0",
         "ts-pattern": "^5.9.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
@@ -1942,16 +1942,16 @@
       }
     },
     "node_modules/@eslint-react/var": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.17.2.tgz",
-      "integrity": "sha512-0WcVVP9Idf1CziGd5Sv/3GHL9lu094AA7QI/H7WY6puIo3CjLP3KKvU7vc7lfwsENSkQl8+Vhu9y/Hk0UyTzVA==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.18.3.tgz",
+      "integrity": "sha512-9nol88aB4PSyOouyh8toTZkuvYzIB1ZEQcLEW+yL3ausDHvFdN8zIxULMLetjdtcvmIoBLpOcW2dgJSwSCl+qg==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@typescript-eslint/scope-manager": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@typescript-eslint/scope-manager": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -2037,9 +2037,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2958,12 +2958,43 @@
       }
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
-      "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.0.tgz",
+      "integrity": "sha512-OqgJ8PN0d04KcPhDX/PTY5tJUJZxlbrt7O7FBsm4XE0XW2JDrKnDXsc9uo9WUimJGPoo2j+JRGhyXApC//mvbw==",
       "license": "MIT",
       "dependencies": {
+        "@eslint-community/eslint-utils": "4.9.1",
         "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3542,9 +3573,9 @@
       }
     },
     "node_modules/@oxc-project/runtime": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.141.0.tgz",
-      "integrity": "sha512-Z/6jQ0dyvE2fVjMUO7GoD4h+3q0G4lI4BWQNjaPhC4RPxaS4hF1b7/QYKB/Tl+KAQwqqKgMF54ukR/VvV5FILg==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.142.0.tgz",
+      "integrity": "sha512-Dv3jRrcXFdvUBUEljUu9kusrEo9G0iiqZFZNg3yCg+mkET4DD4S2Ow6Q6shFWDJwPidSa980d6YVXBlErUGADw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3891,9 +3922,9 @@
       ]
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.60.0.tgz",
-      "integrity": "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.61.0.tgz",
+      "integrity": "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==",
       "cpu": [
         "arm"
       ],
@@ -3908,9 +3939,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.60.0.tgz",
-      "integrity": "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.61.0.tgz",
+      "integrity": "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==",
       "cpu": [
         "arm64"
       ],
@@ -3925,9 +3956,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.60.0.tgz",
-      "integrity": "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.61.0.tgz",
+      "integrity": "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==",
       "cpu": [
         "arm64"
       ],
@@ -3942,9 +3973,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.60.0.tgz",
-      "integrity": "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.61.0.tgz",
+      "integrity": "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==",
       "cpu": [
         "x64"
       ],
@@ -3959,9 +3990,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.60.0.tgz",
-      "integrity": "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.61.0.tgz",
+      "integrity": "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==",
       "cpu": [
         "x64"
       ],
@@ -3976,9 +4007,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.60.0.tgz",
-      "integrity": "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.61.0.tgz",
+      "integrity": "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==",
       "cpu": [
         "arm"
       ],
@@ -3993,9 +4024,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.60.0.tgz",
-      "integrity": "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.61.0.tgz",
+      "integrity": "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==",
       "cpu": [
         "arm"
       ],
@@ -4010,9 +4041,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.60.0.tgz",
-      "integrity": "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.61.0.tgz",
+      "integrity": "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==",
       "cpu": [
         "arm64"
       ],
@@ -4030,9 +4061,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.60.0.tgz",
-      "integrity": "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.61.0.tgz",
+      "integrity": "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==",
       "cpu": [
         "arm64"
       ],
@@ -4050,9 +4081,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.60.0.tgz",
-      "integrity": "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.61.0.tgz",
+      "integrity": "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==",
       "cpu": [
         "ppc64"
       ],
@@ -4070,9 +4101,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.60.0.tgz",
-      "integrity": "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.61.0.tgz",
+      "integrity": "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4090,9 +4121,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.60.0.tgz",
-      "integrity": "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.61.0.tgz",
+      "integrity": "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==",
       "cpu": [
         "riscv64"
       ],
@@ -4110,9 +4141,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.60.0.tgz",
-      "integrity": "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.61.0.tgz",
+      "integrity": "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==",
       "cpu": [
         "s390x"
       ],
@@ -4130,9 +4161,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.60.0.tgz",
-      "integrity": "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.61.0.tgz",
+      "integrity": "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==",
       "cpu": [
         "x64"
       ],
@@ -4150,9 +4181,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.60.0.tgz",
-      "integrity": "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.61.0.tgz",
+      "integrity": "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==",
       "cpu": [
         "x64"
       ],
@@ -4170,9 +4201,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.60.0.tgz",
-      "integrity": "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.61.0.tgz",
+      "integrity": "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==",
       "cpu": [
         "arm64"
       ],
@@ -4187,9 +4218,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.60.0.tgz",
-      "integrity": "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.61.0.tgz",
+      "integrity": "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==",
       "cpu": [
         "arm64"
       ],
@@ -4204,9 +4235,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.60.0.tgz",
-      "integrity": "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.61.0.tgz",
+      "integrity": "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==",
       "cpu": [
         "ia32"
       ],
@@ -4221,9 +4252,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.60.0.tgz",
-      "integrity": "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.61.0.tgz",
+      "integrity": "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==",
       "cpu": [
         "x64"
       ],
@@ -4322,9 +4353,9 @@
       ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
-      "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
+      "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
       "cpu": [
         "arm"
       ],
@@ -4339,9 +4370,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
-      "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
+      "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
       "cpu": [
         "arm64"
       ],
@@ -4356,9 +4387,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
-      "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
+      "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
       "cpu": [
         "arm64"
       ],
@@ -4373,9 +4404,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
-      "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
+      "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
       "cpu": [
         "x64"
       ],
@@ -4390,9 +4421,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
-      "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
+      "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
       "cpu": [
         "x64"
       ],
@@ -4407,9 +4438,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
-      "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
+      "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
       "cpu": [
         "arm"
       ],
@@ -4424,9 +4455,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
-      "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
+      "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
       "cpu": [
         "arm"
       ],
@@ -4441,9 +4472,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
-      "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
+      "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
       "cpu": [
         "arm64"
       ],
@@ -4461,9 +4492,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
-      "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
+      "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
       "cpu": [
         "arm64"
       ],
@@ -4481,9 +4512,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
-      "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
+      "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
       "cpu": [
         "ppc64"
       ],
@@ -4501,9 +4532,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
-      "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
+      "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
       "cpu": [
         "riscv64"
       ],
@@ -4521,9 +4552,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
-      "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
+      "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4541,9 +4572,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
-      "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
+      "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
       "cpu": [
         "s390x"
       ],
@@ -4561,9 +4592,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
-      "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
+      "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
       "cpu": [
         "x64"
       ],
@@ -4581,9 +4612,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
-      "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
+      "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
       "cpu": [
         "x64"
       ],
@@ -4601,9 +4632,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
-      "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
+      "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
       "cpu": [
         "arm64"
       ],
@@ -4618,9 +4649,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
-      "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
+      "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
       "cpu": [
         "arm64"
       ],
@@ -4635,9 +4666,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
-      "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
+      "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
       "cpu": [
         "ia32"
       ],
@@ -4652,9 +4683,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
-      "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
+      "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
       "cpu": [
         "x64"
       ],
@@ -5530,16 +5561,16 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -5552,7 +5583,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -5567,15 +5598,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5591,13 +5622,13 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5612,13 +5643,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5629,9 +5660,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5645,14 +5676,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -5669,9 +5700,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5682,15 +5713,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -5745,15 +5776,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5768,12 +5799,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6234,9 +6265,9 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.6.23",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.23.tgz",
-      "integrity": "sha512-CbrXxQpIUMbeyylGlxaxTgnWYM44et4Nx58swl7+vrTyC9Ttx+hQoy8BGCregbbZ08K5qFhRHeoad1VvERUbkg==",
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.27.tgz",
+      "integrity": "sha512-X1RCAfwbatG4GFbJ/1PIHP9MSZMt0JJThqbYID+vS4L783k6QGlLPe421wQE8dHXuGCcenVLsydiM4qzsYWxhg==",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "^8.58.0",
@@ -6465,14 +6496,14 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.8.tgz",
+      "integrity": "sha512-hqUJyozjE4HtJ3wwf2pOw6LnH/EF9W4+ys2s8arr/3fUdw64vzp/SfPFBVCxsGRv2UfjkIieOeZrQ1FH6Oa5Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "=0.141.0",
-        "@oxc-project/types": "=0.141.0",
+        "@oxc-project/runtime": "=0.142.0",
+        "@oxc-project/types": "=0.142.0",
         "lightningcss": "^1.33.0",
         "postcss": "^8.5.6",
         "yuku-codegen": "^0.5.44",
@@ -6482,12 +6513,20 @@
         "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
+        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
+        "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
+        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
+        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8",
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
         "@arethetypeswrong/core": "^0.18.1",
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -6558,9 +6597,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-core/node_modules/@oxc-project/types": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.141.0.tgz",
-      "integrity": "sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6568,9 +6607,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.6.tgz",
-      "integrity": "sha512-QSZWgfqPx5lrIKZ0vwgVRujRqo7gORcc9Oq4fI1UDjKZFgYz9gXVMibSjEqYU3R1webN6FKTOCnzFmrfXchWYw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.8.tgz",
+      "integrity": "sha512-zcGNhemAhux0/sGDZBK5sHvv5bPm9kj+NhDKs8MYfZMjc51kpzMOV3PWhtTOXjJYDiSxv+Ss4AFj2y2wvQDgWg==",
       "cpu": [
         "arm64"
       ],
@@ -6585,9 +6624,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.6.tgz",
-      "integrity": "sha512-pMQZGCQO0s+akuxbjgh31hOUgrdDndCmfbP7BciJuts436qrBb8KaVzBhNjJQtxD6H8yY21CIOjD8nlrp4eDIw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.8.tgz",
+      "integrity": "sha512-56vcDhYuHg1HSqQlFIEexs9WbDtvT2Z8QXq2pEUYVplmP55ekDGx8+Ibu69jBhk+lNwmLAonCW1alffQxMKirQ==",
       "cpu": [
         "x64"
       ],
@@ -6602,9 +6641,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.6.tgz",
-      "integrity": "sha512-0e6nrJgUDN5WwoDRjyh7KV/jbL7WDUhTEWslI64KGpuvD7M6OoPBXYo8Et176O2ENwf52CKVDjXwuvMMNIAzAA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.8.tgz",
+      "integrity": "sha512-EU9zlSieuouJlnLEkVNw9guig5rTQ5hfMeNH0AlRjb1C1xVpUQdf0uRjXg1PHP3os/WspyCPB46Q80lEaeRb0w==",
       "cpu": [
         "arm64"
       ],
@@ -6622,9 +6661,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.6.tgz",
-      "integrity": "sha512-j2yvyv3r2ZEuJG73rWlXFrYrxA7u5+bFSlWTqhsfHZhdb1FKMkklfYRuLtBBdBRLXJ+YMNt9GZT6VTVPJDZnnQ==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.8.tgz",
+      "integrity": "sha512-VbWUwaSAw0Ndql5uYy/Gfqt7duSy1sxTacLngD5M5kF4ZK7yoKKcx8iFiA0il1Gf3J7OGojPonKi5b3NSn3K7A==",
       "cpu": [
         "arm64"
       ],
@@ -6642,9 +6681,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.6.tgz",
-      "integrity": "sha512-5vqldBBnRjIAUmQ88oKli+wPd5vSQaA2AZ2xs+omRlZfeJhC8chlud6DyJV6fVZCC9GI4otK2zSGpfQZx8Kc3A==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.8.tgz",
+      "integrity": "sha512-gZfnd3l9vNiP7QXQIEN9r2M9ZKCh8sg2vhBv04sZjMNAeQ05IXJMkWYkcfTUO7jhf8pdVt3VHQ4x6ULm0OnELg==",
       "cpu": [
         "x64"
       ],
@@ -6662,9 +6701,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.6.tgz",
-      "integrity": "sha512-29ned+euDKAl+BmCigzGrPykQ/kxTjtsPGV6G3hkImwakHNUnmLRayqmsWKHSwXmBk5xo5m+wqjMbo3G0npJQg==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.8.tgz",
+      "integrity": "sha512-5NtDUvjzF/HcjQraebpiVUgjX2CMKv2Jdmi5YpzHlt4g86sFA9M5a+OqBlgUctdzTeolnjxRsfurKiefG/hILA==",
       "cpu": [
         "x64"
       ],
@@ -6682,9 +6721,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.6.tgz",
-      "integrity": "sha512-4b5ASpQlkxSXDYzuM6MYsOc1GnYkqG9CbSA1QzobXm87V/Q+MGPn57eILyacgfbmNNLrO2HQ5hasoLvd2BXaSg==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.8.tgz",
+      "integrity": "sha512-Atjz6KsG42ntfQkM6Ks09Ifxm+ZIca2DnA31tO2FcPlHetBxYEGZwSNCOHAnoNnLrh2qNm+7aOC329a2ijhxLg==",
       "cpu": [
         "arm64"
       ],
@@ -6699,9 +6738,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.6.tgz",
-      "integrity": "sha512-rvGkm4WmVkCKPhvUbLkRtlVhi7EYb8GU8KaqIGJ0dVfNQHDEqnFboaiUHuPN1npFNwB+80Ulzz9AkQ/Q8MswQA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.8.tgz",
+      "integrity": "sha512-VSpa+gK1MjOH7GeO6H5xtJLqisQOWVeRQIDQs9XKizXFX0R4NCrioYO6Rc31QLXfL0lPCkwsKhp/9M9gllImRg==",
       "cpu": [
         "x64"
       ],
@@ -9397,9 +9436,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -9409,7 +9448,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -9433,7 +9472,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -9552,16 +9591,16 @@
       }
     },
     "node_modules/eslint-plugin-cypress": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-6.4.3.tgz",
-      "integrity": "sha512-2/ulKNnCn+0vbaDI/6KovgGKsR/Y/bA+KMAkxRbHl2IAMd/UzU24ZOXpncR+QPBlaXqfAJ9NMCzdwX9Gjhm9AQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-7.0.0.tgz",
+      "integrity": "sha512-gpvL3S1w45c0DORI/P5v3k1UUW2NKje3JiFz+oTHGF6dZa6ZPBokItJS7jP0BXGPEgI3RpHyAMNMAJ9K5P0bow==",
       "license": "MIT",
       "dependencies": {
-        "globals": "^17.7.0"
+        "globals": "^17.9.0"
       },
       "peerDependencies": {
         "@typescript-eslint/parser": ">=8",
-        "eslint": ">=9"
+        "eslint": ">=10"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/parser": {
@@ -9663,9 +9702,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.15.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.4.tgz",
-      "integrity": "sha512-6ln5i9Nkrb27X4w91ZPt/xHDsVQnvxTS2ntgq6r32u+8gymdUrp88TdcBXSveZW0Dl+M5v2H6K75kJhMvUGhjg==",
+      "version": "29.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.16.0.tgz",
+      "integrity": "sha512-0WFBxDHlT2ratGQfnFQEVIsgQJ5cfd+0IV8Kc6U3X2onB8ATLG23voD2Ch5G9fCkEpCPmCMuzW0tbS0kYb8biw==",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0"
@@ -9677,7 +9716,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "jest": "*",
-        "typescript": ">=4.8.4 <7.0.0"
+        "typescript": ">=4.8.4 <8.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {
@@ -9721,9 +9760,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.1.tgz",
-      "integrity": "sha512-aO3C9//yq8JIvYOi/T+jPvcZ9hZzpwzbR8esrYpFtgE9vpbyM8kn42AQOtIqYspVmpaSWr8X+nrlQuAJYxXAaw==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.3.0.tgz",
+      "integrity": "sha512-cPVguuDe6DrIPb/qUXHf8P89MaVTUmiYWwpt5gX5AILsvRIiZAxMFXcFR6QHYBksqKJpjfUBlL/RleCJUWcD7w==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.5.0",
@@ -9768,12 +9807,12 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.10.0.tgz",
-      "integrity": "sha512-HiqpDrUDbGrMC6iHQbemgDyHJ0366Vyz/qRWmxQcSAkmG25cXr8BdRgx8yAhOKhEfBXn8Rnf/mTCsV4EqUJSxg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.10.1.tgz",
+      "integrity": "sha512-Kprsp9Us0GqAesYaAIzUViw57xYp5WBqzXrcE0Mtww++E5fexWXYBipMuuD7yvyH4vvpBH0+oJ+OMAmZ0oYXkw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.62.1",
+        "@typescript-eslint/utils": "^8.65.0",
         "natural-orderby": "^5.0.0"
       },
       "engines": {
@@ -9784,9 +9823,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.5.tgz",
-      "integrity": "sha512-4k+ml4cEd55kePUIW1WsCiOLDwZkAdPZPKMFulR83XpplCaVOTKHF6yvXLYixLtdVbkMjmKV5F3BaGuI3aH8aQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.11.0.tgz",
+      "integrity": "sha512-zOIEYyv1TSn2izXkyg/yj0LXc4YBQI6pl3xIFWwMCcXt/dgQCz8dBqXiXFMoM3xc/GqZThAtaGYo8aPu/vBd+Q==",
       "license": "MIT",
       "dependencies": {
         "globals": "^17.3.0"
@@ -9847,17 +9886,17 @@
       }
     },
     "node_modules/eslint-plugin-react-dom": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.17.2.tgz",
-      "integrity": "sha512-QDiC7ygSh9RtdcFAmMBDFgo+kp5VYIetgb3T48PdajUXpTh0ys/2ujqIgoD8EA2TH+cXfXWEbHKzcJssoFI+Vg==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.18.3.tgz",
+      "integrity": "sha512-iGZys8sreyijVkaWG41HBugjgduh4kSOu4Jyk2wLOjo7Ssn9hga2B6LOLoAP63IoFnHWs9TDVv7Tb0zEupvcSQ==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/jsx": "5.17.2",
-        "@eslint-react/shared": "5.17.2",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/jsx": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "compare-versions": "^6.1.1"
       },
       "engines": {
@@ -9869,18 +9908,18 @@
       }
     },
     "node_modules/eslint-plugin-react-jsx": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.17.2.tgz",
-      "integrity": "sha512-3u/MK/IGGguyLccMBMh9DJgUTYnnC9qjTCBTpFxGjgQHT8ArskGqWq2R6g3D23gs9UxCV2yaN/cA8+pVcFGdgw==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.18.3.tgz",
+      "integrity": "sha512-/qNyr4eYy4RNgIown6grxmJUNx1wYWqXd0wCd1P1Rc6wbQTwGB6bpnZMXMTOBpPrs0mgAgCPAscFOV/mvm6MAw==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/core": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/jsx": "5.17.2",
-        "@eslint-react/shared": "5.17.2",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0"
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/core": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/jsx": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -9891,17 +9930,18 @@
       }
     },
     "node_modules/eslint-plugin-react-naming-convention": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.17.2.tgz",
-      "integrity": "sha512-TaiXabQxUb5QTS83afaSYt2V2pIG+lI7GAhCC11VmbkuPgjAB0CClTa50AQPmKc9QiwOMGUfcLN+IziuEUBfqw==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.18.3.tgz",
+      "integrity": "sha512-dLVqpOtFbw7juVrfWvHqnS266h+6eF99opK9d1JlnXbjMSjWFlteIsQ7028cjNkgkObdZhLx50CxCJ0EnBfnyQ==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/core": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/var": "5.17.2",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/core": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@eslint-react/var": "5.18.3",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -9913,27 +9953,27 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
-      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.4.tgz",
+      "integrity": "sha512-7bqTKz7T0r+HKWFarNXByDE9/5+73wI2ru+M3zuqGbR7s/b/5/pQJXZoufWlrngqGqoZto73ZkGumCdLxk+4rw==",
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^9 || ^10"
       }
     },
     "node_modules/eslint-plugin-react-rsc": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.17.2.tgz",
-      "integrity": "sha512-wF5AttunII+Yt1Nj1qJHuDUYL1Dk2QndFSfoa3tYDqXHaMrXA0kZ2/7PxXh6YNE5J1bRG10nRXjwqXquqDyYbw==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.18.3.tgz",
+      "integrity": "sha512-7+NVV+PEQ2Jst/05AY9RlqeFgd2gRQBNf6vZ32T8qMOR19YVv6qATTPVOW1NBTKHC4dHjUl7XXohWQ+FEWpcfw==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/core": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/shared": "5.17.2",
-        "@eslint-react/var": "5.17.2",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0"
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/core": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@eslint-react/var": "5.18.3",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -9944,18 +9984,18 @@
       }
     },
     "node_modules/eslint-plugin-react-web-api": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.17.2.tgz",
-      "integrity": "sha512-I+uazjAj7/6Lw9HZ1f15BMqqXZXhER/1gwzDFQBP+vI4f5x6PsW1up4wj32k3n5hdsLLTSvGzER0IknvmcmR/A==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.18.3.tgz",
+      "integrity": "sha512-HlOCcicEaNp2I7jM9fTtuhZg61EFvdurRhuxnRtRP4X7qRroS0nZ683zJ1I+jJ1F+LkATwUWiHg4WMvsQ00ePQ==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/core": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/shared": "5.17.2",
-        "@eslint-react/var": "5.17.2",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/core": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@eslint-react/var": "5.18.3",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "birecord": "^0.1.2",
         "ts-pattern": "^5.9.0"
       },
@@ -9968,22 +10008,22 @@
       }
     },
     "node_modules/eslint-plugin-react-x": {
-      "version": "5.17.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.17.2.tgz",
-      "integrity": "sha512-92zUMkJAfbm7BX3lxSvDHFfimHX8lHfBMWRFaPyRyV7Q9NhGPH7GkG3LALjU6jj7zpMpk+/t4uh5OURQ79TS8Q==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.18.3.tgz",
+      "integrity": "sha512-hkqWrDcp2wzsEHxhPeMkD8bB5yU5cCQMLeJSQ78r8sNZtktVGmV5YU+7yTUMKfApK+XkXLa7dAujdwhhS1fTiA==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.17.2",
-        "@eslint-react/core": "5.17.2",
-        "@eslint-react/eslint": "5.17.2",
-        "@eslint-react/jsx": "5.17.2",
-        "@eslint-react/shared": "5.17.2",
-        "@eslint-react/var": "5.17.2",
-        "@typescript-eslint/scope-manager": "^8.64.0",
-        "@typescript-eslint/type-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
-        "@typescript-eslint/typescript-estree": "^8.64.0",
-        "@typescript-eslint/utils": "^8.64.0",
+        "@eslint-react/ast": "5.18.3",
+        "@eslint-react/core": "5.18.3",
+        "@eslint-react/eslint": "5.18.3",
+        "@eslint-react/jsx": "5.18.3",
+        "@eslint-react/shared": "5.18.3",
+        "@eslint-react/var": "5.18.3",
+        "@typescript-eslint/scope-manager": "^8.66.0",
+        "@typescript-eslint/type-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/typescript-estree": "^8.66.0",
+        "@typescript-eslint/utils": "^8.66.0",
         "compare-versions": "^6.1.1",
         "string-ts": "^2.3.1",
         "ts-api-utils": "^2.5.0",
@@ -10019,17 +10059,17 @@
       }
     },
     "node_modules/eslint-plugin-storybook": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.5.2.tgz",
-      "integrity": "sha512-BPTbb8OKNAlQ2XubEQ6H1TeHG9nMygLrHC8cSVTfdIat65qbS568WYgNg//zlJWtZ9ZamyVkCp/na+LBbFPseA==",
+      "version": "10.5.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.5.7.tgz",
+      "integrity": "sha512-mLpamG1Rsica2jYbUzIZOEuy7Fm1IMtVLMvvxGTpjTVKUMxTXJsANx3MBpH2VSbGQB8Yzlt5399WL/O07K97Ig==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.48.0",
-        "@typescript-eslint/utils": "^8.48.0"
+        "@typescript-eslint/types": "^8.60.0",
+        "@typescript-eslint/utils": "^8.60.0"
       },
       "peerDependencies": {
         "eslint": ">=8",
-        "storybook": "^10.5.2"
+        "storybook": "^10.5.7"
       }
     },
     "node_modules/eslint-scope": {
@@ -10874,9 +10914,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.10.0.tgz",
+      "integrity": "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16340,9 +16380,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.60.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.60.0.tgz",
-      "integrity": "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==",
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.61.0.tgz",
+      "integrity": "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16358,25 +16398,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.60.0",
-        "@oxfmt/binding-android-arm64": "0.60.0",
-        "@oxfmt/binding-darwin-arm64": "0.60.0",
-        "@oxfmt/binding-darwin-x64": "0.60.0",
-        "@oxfmt/binding-freebsd-x64": "0.60.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.60.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.60.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.60.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.60.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.60.0",
-        "@oxfmt/binding-linux-x64-musl": "0.60.0",
-        "@oxfmt/binding-openharmony-arm64": "0.60.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.60.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.60.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.60.0"
+        "@oxfmt/binding-android-arm-eabi": "0.61.0",
+        "@oxfmt/binding-android-arm64": "0.61.0",
+        "@oxfmt/binding-darwin-arm64": "0.61.0",
+        "@oxfmt/binding-darwin-x64": "0.61.0",
+        "@oxfmt/binding-freebsd-x64": "0.61.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.61.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.61.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.61.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.61.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.61.0",
+        "@oxfmt/binding-linux-x64-musl": "0.61.0",
+        "@oxfmt/binding-openharmony-arm64": "0.61.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.61.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.61.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.61.0"
       },
       "peerDependencies": {
         "svelte": "^5.0.0",
@@ -16392,9 +16432,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
-      "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
+      "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -16407,25 +16447,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.75.0",
-        "@oxlint/binding-android-arm64": "1.75.0",
-        "@oxlint/binding-darwin-arm64": "1.75.0",
-        "@oxlint/binding-darwin-x64": "1.75.0",
-        "@oxlint/binding-freebsd-x64": "1.75.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.75.0",
-        "@oxlint/binding-linux-arm64-musl": "1.75.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.75.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.75.0",
-        "@oxlint/binding-linux-x64-gnu": "1.75.0",
-        "@oxlint/binding-linux-x64-musl": "1.75.0",
-        "@oxlint/binding-openharmony-arm64": "1.75.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.75.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.75.0",
-        "@oxlint/binding-win32-x64-msvc": "1.75.0"
+        "@oxlint/binding-android-arm-eabi": "1.76.0",
+        "@oxlint/binding-android-arm64": "1.76.0",
+        "@oxlint/binding-darwin-arm64": "1.76.0",
+        "@oxlint/binding-darwin-x64": "1.76.0",
+        "@oxlint/binding-freebsd-x64": "1.76.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.76.0",
+        "@oxlint/binding-linux-arm64-musl": "1.76.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.76.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-gnu": "1.76.0",
+        "@oxlint/binding-linux-x64-musl": "1.76.0",
+        "@oxlint/binding-openharmony-arm64": "1.76.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.76.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.76.0",
+        "@oxlint/binding-win32-x64-msvc": "1.76.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -17019,9 +17059,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -17775,9 +17815,9 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "25.0.8",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
-      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
+      "version": "25.0.9",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.9.tgz",
+      "integrity": "sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18491,16 +18531,16 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.2.tgz",
-      "integrity": "sha512-zkYxVZoDMj8njzZc3EH5UyY7885wpi9a1mmWVwFiNHSo+i5r2Go84E2OI1cdOctRymLkNvgs1j5jqAKA0ftBqg==",
+      "version": "10.5.7",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.7.tgz",
+      "integrity": "sha512-oiKvWIwIoOhFP1i6dASYyMXwPHKEtVZMshqSB7EvIVYjWRh0l9H7gHEt1z4Gh2rLGFMekWdsm4s94rvwpR7gkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
         "@testing-library/dom": "^10.4.1",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/jest-dom": "6.9.1",
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
         "@vitest/spy": "3.2.4",
@@ -18513,7 +18553,7 @@
         "recast": "^0.23.5",
         "semver": "^7.7.3",
         "use-sync-external-store": "^1.5.0",
-        "ws": "^8.18.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "storybook": "dist/bin/dispatcher.js"
@@ -19419,15 +19459,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.65.0",
-        "@typescript-eslint/parser": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19776,13 +19816,13 @@
       }
     },
     "node_modules/vite-plus": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.6.tgz",
-      "integrity": "sha512-fFX8GLENhtzvnE4NmTPC8INRxjD2kZKcqUW0p7jOdawmHTNZqM5FiieyWOG6WH1a/axu9FCsbUNb918grfzDTw==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.8.tgz",
+      "integrity": "sha512-JULDOsy7gxG0o2FuvnsWnzRjzD1x9WM9mya3MNMOJUqTsL2pqiN2nq+dzoQMw+FGCytRw7yG1/p5qNcmYMM5Fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.141.0",
+        "@oxc-project/types": "=0.142.0",
         "@oxlint/plugins": "=1.73.0",
         "@vitest/browser": "4.1.10",
         "@vitest/browser-preview": "4.1.10",
@@ -19793,9 +19833,9 @@
         "@vitest/snapshot": "4.1.10",
         "@vitest/spy": "4.1.10",
         "@vitest/utils": "4.1.10",
-        "@voidzero-dev/vite-plus-core": "0.2.6",
-        "oxfmt": "=0.60.0",
-        "oxlint": "=1.75.0",
+        "@voidzero-dev/vite-plus-core": "0.2.8",
+        "oxfmt": "=0.61.0",
+        "oxlint": "=1.76.0",
         "oxlint-tsgolint": "=7.0.2001",
         "vitest": "4.1.10"
       },
@@ -19809,14 +19849,14 @@
         "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
-        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.6",
-        "@voidzero-dev/vite-plus-darwin-x64": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.6"
+        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
+        "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
+        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
+        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
+        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8"
       },
       "peerDependencies": {
         "@vitest/browser-playwright": "4.1.10",
@@ -19832,9 +19872,9 @@
       }
     },
     "node_modules/vite-plus/node_modules/@oxc-project/types": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.141.0.tgz",
-      "integrity": "sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -75,10 +75,10 @@
     "vitest": "4.1.10"
   },
   "peerDependencies": {
-    "cypress": ">=8",
-    "eslint": ">=9.38",
+    "cypress": ">=15",
+    "eslint": ">=10.3.0",
     "prettier": ">=3",
-    "react": ">=18",
+    "react": ">=19",
     "tailwindcss": ">=3.3.0",
     "typescript": ">=5"
   },

--- a/package.json
+++ b/package.json
@@ -10,15 +10,10 @@
   },
   "files": [
     "src",
-    "cjs"
+    "dist"
   ],
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    },
+    ".": "./dist/index.mjs",
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -37,29 +37,29 @@
     "check:rules": "node scripts/check-missing-rules.mjs"
   },
   "dependencies": {
-    "@eslint-react/eslint-plugin": "5.17.2",
+    "@eslint-react/eslint-plugin": "5.18.3",
     "@eslint/compat": "2.1.0",
-    "@next/eslint-plugin-next": "16.2.10",
+    "@next/eslint-plugin-next": "16.3.0",
     "@stylistic/eslint-plugin": "5.10.0",
-    "@vitest/eslint-plugin": "1.6.23",
+    "@vitest/eslint-plugin": "1.6.27",
     "deepmerge": "4.3.1",
     "eslint-flat-config-utils": "3.2.0",
     "eslint-plugin-better-tailwindcss": "4.7.0",
-    "eslint-plugin-cypress": "6.4.3",
+    "eslint-plugin-cypress": "7.0.0",
     "eslint-plugin-import-x": "4.17.1",
-    "eslint-plugin-jest": "29.15.4",
+    "eslint-plugin-jest": "29.16.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
-    "eslint-plugin-n": "18.2.1",
-    "eslint-plugin-perfectionist": "5.10.0",
-    "eslint-plugin-playwright": "2.10.5",
+    "eslint-plugin-n": "18.3.0",
+    "eslint-plugin-perfectionist": "5.10.1",
+    "eslint-plugin-playwright": "2.11.0",
     "eslint-plugin-prettier": "5.5.6",
     "eslint-plugin-promise": "7.3.0",
-    "eslint-plugin-react-refresh": "0.5.3",
+    "eslint-plugin-react-refresh": "0.5.4",
     "eslint-plugin-regexp": "3.1.1",
-    "eslint-plugin-storybook": "10.5.2",
-    "globals": "17.7.0",
+    "eslint-plugin-storybook": "10.5.7",
+    "globals": "17.10.0",
     "local-pkg": "1.2.1",
-    "typescript-eslint": "8.65.0"
+    "typescript-eslint": "8.67.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.6",
@@ -69,14 +69,14 @@
     "@semantic-release/release-notes-generator": "14.1.1",
     "@types/eslint": "9.6.1",
     "cspell": "10.0.1",
-    "eslint": "10.7.0",
+    "eslint": "10.8.1",
     "jest": "30.4.2",
     "pinst": "3.0.0",
-    "prettier": "3.9.5",
-    "semantic-release": "25.0.8",
-    "storybook": "10.5.2",
+    "prettier": "3.9.6",
+    "semantic-release": "25.0.9",
+    "storybook": "10.5.7",
     "typescript": "6.0.3",
-    "vite-plus": "0.2.6",
+    "vite-plus": "0.2.8",
     "vitest": "4.1.10"
   },
   "peerDependencies": {
@@ -111,5 +111,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "npm@12.0.1"
+  "packageManager": "npm@12.0.2"
 }

--- a/src/modules/base.mjs
+++ b/src/modules/base.mjs
@@ -11,6 +11,9 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function base(options = {}) {
   const overrides = objectOrEmpty(options.base.overrides);
 
+  /**
+   * @type { import('eslint/config').ConfigObject }
+   */
   const baseConfig = {
     name: 'base',
     languageOptions: {

--- a/src/modules/cypress.mjs
+++ b/src/modules/cypress.mjs
@@ -11,6 +11,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function cypress(options = {}) {
   const overrides = objectOrEmpty(options.cypress.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const cypressConfig = {
     name: 'cypress',
     files: globs.e2e,

--- a/src/modules/imports.mjs
+++ b/src/modules/imports.mjs
@@ -16,6 +16,7 @@ function imports(options = {}) {
   const isObject = typeof options.import === 'object';
   const overrides = objectOrEmpty(options.import.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const importsConfig = {
     name: 'imports',
     plugins: { import: plugin },

--- a/src/modules/jest.mjs
+++ b/src/modules/jest.mjs
@@ -13,6 +13,7 @@ function jest(options = {}) {
   const projectService = options.typescript && options.typescript.tsconfigRootDir && options.typescript.projectService;
   const overrides = objectOrEmpty(options.jest.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const jestConfig = {
     name: 'jest',
     files: globs.test,

--- a/src/modules/next.mjs
+++ b/src/modules/next.mjs
@@ -10,6 +10,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function next(options = {}) {
   const overrides = objectOrEmpty(options.next.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const nextConfig = {
     name: 'next',
     plugins: { next: plugin },

--- a/src/modules/node.mjs
+++ b/src/modules/node.mjs
@@ -11,6 +11,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function node(options = {}) {
   const overrides = objectOrEmpty(options.node.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const nodeConfig = {
     name: 'node',
     plugins: { n: plugin },
@@ -46,7 +47,9 @@ function node(options = {}) {
       'n/prefer-global/timers': 'warn',
       'n/prefer-global/url-search-params': 'warn',
       'n/prefer-global/url': 'warn',
+      '/prefer-import/assert-strict': 'warn',
       'n/prefer-node-protocol': 'warn',
+      'n/prefer-process-get-builtin-module': 'warn',
       'n/prefer-promises/dns': 'warn',
       'n/prefer-promises/fs': 'warn',
       'n/process-exit-as-throw': 'error',

--- a/src/modules/perfectionist.mjs
+++ b/src/modules/perfectionist.mjs
@@ -10,6 +10,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function perfectionist(options = {}) {
   const overrides = objectOrEmpty(options.sort.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const perfectionistConfig = {
     name: 'perfectionist',
     plugins: { perfectionist: plugin },

--- a/src/modules/playwright.mjs
+++ b/src/modules/playwright.mjs
@@ -11,6 +11,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function playwright(options = {}) {
   const overrides = objectOrEmpty(options.playwright.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const playwrightConfig = {
     name: 'playwright',
     plugins: { playwright: plugin },

--- a/src/modules/prettier.mjs
+++ b/src/modules/prettier.mjs
@@ -10,6 +10,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function prettier(options = {}) {
   const overrides = objectOrEmpty(options.prettier.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const prettierConfig = {
     name: 'prettier',
     plugins: { prettier: plugin },

--- a/src/modules/promise.mjs
+++ b/src/modules/promise.mjs
@@ -11,6 +11,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function promise(options = {}) {
   const overrides = objectOrEmpty(options.promise.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const promiseConfig = {
     name: 'promise',
     plugins: { promise: plugin },

--- a/src/modules/react.mjs
+++ b/src/modules/react.mjs
@@ -19,6 +19,7 @@ function react(options = {}) {
   const isObject = typeof options.react === 'object';
   const overrides = objectOrEmpty(options.react.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const reactConfig = {
     name: 'react',
     files: [globs.js, globs.jsx, globs.ts, globs.tsx],
@@ -76,6 +77,7 @@ function react(options = {}) {
       '@eslint-react/jsx-no-children-prop': 'warn',
       '@eslint-react/jsx-no-children-prop-with-children': 'warn',
       '@eslint-react/jsx-no-key-after-spread': 'error',
+      '@eslint-react/no-leaked-dollar': 'error',
       '@eslint-react/jsx-no-useless-fragment': 'warn',
       '@eslint-react/jsx-no-namespace': 'error',
 

--- a/src/modules/regex.mjs
+++ b/src/modules/regex.mjs
@@ -12,6 +12,7 @@ function regex(options = {}) {
   const isObject = typeof options.regex === 'object';
   const overrides = objectOrEmpty(options.regex.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const regexConfig = {
     name: 'regex',
     plugins: { regexp: plugin },

--- a/src/modules/storybook.mjs
+++ b/src/modules/storybook.mjs
@@ -11,6 +11,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function storybook(options = {}) {
   const overrides = objectOrEmpty(options.storybook.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const storybookConfig = {
     name: 'storybook',
     files: globs.storybook,

--- a/src/modules/stylistic.mjs
+++ b/src/modules/stylistic.mjs
@@ -10,6 +10,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function stylistic(options = {}) {
   const overrides = objectOrEmpty(options.stylistic.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const stylisticConfig = {
     name: 'stylistic',
     plugins: { '@stylistic': stylisticPlugin },

--- a/src/modules/tailwind.mjs
+++ b/src/modules/tailwind.mjs
@@ -12,6 +12,7 @@ async function tailwind(options = {}) {
   const isObject = typeof options.tailwind === 'object';
   const overrides = objectOrEmpty(options.tailwind.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const tailwindConfig = {
     name: 'tailwind',
     plugins: { 'better-tailwindcss': plugin.default ?? plugin },

--- a/src/modules/tests.mjs
+++ b/src/modules/tests.mjs
@@ -14,6 +14,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function tests(options = {}) {
   const overrides = objectOrEmpty(options.test.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const testsConfug = {
     name: 'tests',
     files: [...globs.test, ...globs.e2e],

--- a/src/modules/typescript.mjs
+++ b/src/modules/typescript.mjs
@@ -14,6 +14,7 @@ function typescript(options = {}) {
   const projectService = options.typescript && options.typescript.tsconfigRootDir && options.typescript.projectService;
   const overrides = objectOrEmpty(options.typescript.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const typescriptConfig = {
     name: 'typescript',
     files: [globs.ts, globs.tsx],

--- a/src/modules/vitest.mjs
+++ b/src/modules/vitest.mjs
@@ -11,6 +11,7 @@ import { objectOrEmpty } from '../utils/objectOrEmpty.mjs';
 function vitest(options = {}) {
   const overrides = objectOrEmpty(options.vitest.overrides);
 
+  /** @type { import('eslint/config').ConfigObject } */
   const vitestConfig = {
     name: 'vitest',
     files: globs.test,

--- a/src/utils/nextAllowExportNames.mjs
+++ b/src/utils/nextAllowExportNames.mjs
@@ -7,11 +7,18 @@ export const nextAllowExportNames = [
   'runtime',
   'preferredRegion',
   'maxDuration',
+  // https://nextjs.org/docs/app/api-reference/functions/generate-metadata
   'metadata',
   'generateMetadata',
+  // https://nextjs.org/docs/app/api-reference/functions/generate-viewport
   'viewport',
   'generateViewport',
+  // https://nextjs.org/docs/app/api-reference/functions/generate-image-metadata
   'generateImageMetadata',
+  // https://nextjs.org/docs/app/api-reference/functions/generate-sitemaps
   'generateSitemaps',
+  // https://nextjs.org/docs/app/api-reference/functions/generate-static-params
   'generateStaticParams',
+  // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant
+  'instant',
 ];

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite-plus';
 export default defineConfig({
   pack: {
     entry: ['./src/index.mjs'],
-    format: ['esm', 'cjs'],
+    format: ['esm'],
     exports: true,
   },
   fmt: {


### PR DESCRIPTION
Update pachages.
Updated the build configuration to generate `ESM-only` output with no `CJS` bundles.
Updated peer dependency requirements:
`React >=19`
`ESLint >=10.3.0`
`Cypress >=15`

